### PR TITLE
fix: resolve PSScriptAnalyzer lint warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run PSScriptAnalyzer
         shell: pwsh
         run: |
-          $results = Invoke-ScriptAnalyzer -Path ./scripts -Recurse -Severity Error,Warning
+          $results = Invoke-ScriptAnalyzer -Path ./scripts -Recurse -Severity Error,Warning -Settings .pssa-settings.psd1
           if ($results) {
             $results | Format-Table -AutoSize
             Write-Host "::error::PSScriptAnalyzer found $($results.Count) issue(s)"

--- a/.pssa-settings.psd1
+++ b/.pssa-settings.psd1
@@ -1,0 +1,8 @@
+@{
+    ExcludeRules = @(
+        # Interactive console tools — Write-Host is intentional for coloured output
+        'PSAvoidUsingWriteHost',
+        # Files authored on Linux/WSL without BOM — not a functional issue
+        'PSUseBOMForUnicodeEncodedFile'
+    )
+}

--- a/scripts/Test-PrivateDNSConnectivity.ps1
+++ b/scripts/Test-PrivateDNSConnectivity.ps1
@@ -52,7 +52,9 @@ $results = foreach ($record in $records) {
         $connected = $task.Wait($TimeoutMs) -and $tcp.Connected
         $tcp.Close()
     }
-    catch { }
+    catch {
+        $connected = $false
+    }
 
     [PSCustomObject]@{
         Status = if ($connected) { 'REACHABLE' } else { 'UNREACHABLE' }


### PR DESCRIPTION
Fixes the CI lint failures on main.

- Fix empty catch block in Test-PrivateDNSConnectivity.ps1 (add explicit `$connected = $false`)
- Add `.pssa-settings.psd1` to exclude by-design rules: `PSAvoidUsingWriteHost` (coloured console output is intentional) and `PSUseBOMForUnicodeEncodedFile` (Linux-authored files)
- Update lint.yml to pass `-Settings .pssa-settings.psd1`